### PR TITLE
review: 회원 가입 에러케이스: 사용중인 이메일인 경우

### DIFF
--- a/src/main/kotlin/com/jys/kotlin_practice/account/AccountService.kt
+++ b/src/main/kotlin/com/jys/kotlin_practice/account/AccountService.kt
@@ -3,9 +3,7 @@ package com.jys.kotlin_practice.account
 import com.jys.kotlin_practice.account.error.AccountError
 import com.jys.kotlin_practice.error.BadRequestErrorCodeException
 import com.jys.kotlin_practice.keycloak.KeycloakClient
-import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
-import org.springframework.web.server.ResponseStatusException
 
 @Service
 class AccountService (
@@ -20,7 +18,7 @@ class AccountService (
         if(signupRequest.password != signupRequest.passwordCheck) throw BadRequestErrorCodeException(AccountError.DIFFERENT_PASSWORD)
 
         // 사용자 존재 여부 검증
-        if(keycloakClient.getByEmail(signupRequest.email) == null) throw ResponseStatusException(HttpStatus.CONFLICT)
+        if(keycloakClient.getByEmail(signupRequest.email) == null) throw BadRequestErrorCodeException(AccountError.EMAIL_EXIST)
 
         keycloakClient.registerBy(signupRequest)
     }

--- a/src/main/kotlin/com/jys/kotlin_practice/account/error/AccountError.kt
+++ b/src/main/kotlin/com/jys/kotlin_practice/account/error/AccountError.kt
@@ -3,5 +3,6 @@ package com.jys.kotlin_practice.account.error
 import com.jys.kotlin_practice.error.Error
 
 enum class AccountError(override val message: String) : Error {
-    DIFFERENT_PASSWORD("비밀번호가 일치하지 않습니다")
+    DIFFERENT_PASSWORD("비밀번호가 일치하지 않습니다"),
+    EMAIL_EXIST("사용중인 이메일 입니다")
 }

--- a/src/main/kotlin/com/jys/kotlin_practice/config/KeycloakConfiguration.kt
+++ b/src/main/kotlin/com/jys/kotlin_practice/config/KeycloakConfiguration.kt
@@ -1,28 +1,19 @@
 package com.jys.kotlin_practice.config
 
 import com.jys.kotlin_practice.keycloak.KeycloakClient
-import org.springframework.beans.factory.annotation.Value
+import com.jys.kotlin_practice.keycloak.KeycloakProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 
 @Configuration
-class KeycloakConfiguration(
-    @Value("\${keycloak.realm}")
-    private val realm: String,
-    @Value("\${keycloak.grant_type}")
-    private val grantType: String,
-    @Value("\${keycloak.auth-server-url}")
-    private val authUrl: String,
-    @Value("\${keycloak.clientId}")
-    private val clientId: String,
-    @Value("\${keycloak.client_secret}")
-    private val clientSecret: String
-) {
+@EnableConfigurationProperties(value = [KeycloakProperties::class])
+class KeycloakConfiguration {
     /**
      * keycloak client
      */
     @Bean
-    fun keycloakClient(): KeycloakClient =
-        KeycloakClient(realm, grantType, authUrl, clientId, clientSecret)
+    fun keycloakClient(keycloakProperties: KeycloakProperties): KeycloakClient =
+        KeycloakClient(keycloakProperties)
 }

--- a/src/main/kotlin/com/jys/kotlin_practice/keycloak/KeycloakClient.kt
+++ b/src/main/kotlin/com/jys/kotlin_practice/keycloak/KeycloakClient.kt
@@ -7,20 +7,16 @@ import org.springframework.http.HttpStatus
 import org.springframework.web.server.ResponseStatusException
 
 class KeycloakClient(
-    realm: String,
-    grantType: String,
-    authUrl: String,
-    clientId: String,
-    clientSecret: String
+    keycloakProperties: KeycloakProperties
 ) {
     private val realmResource: RealmResource =
         KeycloakBuilder.builder()
-            .realm(realm)
-            .grantType(grantType)
-            .serverUrl(authUrl)
-            .clientId(clientId)
-            .clientSecret(clientSecret)
-            .build().realm(realm)
+            .realm(keycloakProperties.realm)
+            .grantType(keycloakProperties.grantType)
+            .serverUrl(keycloakProperties.authServerUrl)
+            .clientId(keycloakProperties.clientId)
+            .clientSecret(keycloakProperties.clientSecret)
+            .build().realm(keycloakProperties.realm)
 
     /**
      * keycloak 회원 생성
@@ -54,7 +50,7 @@ class KeycloakClient(
      * @param id 회원 번호
      */
     private fun addRestClientRole(id: String) {
-        val role = getRoleByName(KeyCloakRoles.REST_CLIENT)
+        val role = getRoleByName(KeycloakRoles.REST_CLIENT)
         realmResource.users().get(id).roles().realmLevel().add(listOf(role))
     }
 

--- a/src/main/kotlin/com/jys/kotlin_practice/keycloak/KeycloakProperties.kt
+++ b/src/main/kotlin/com/jys/kotlin_practice/keycloak/KeycloakProperties.kt
@@ -1,0 +1,14 @@
+package com.jys.kotlin_practice.keycloak
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+
+@ConstructorBinding
+@ConfigurationProperties(prefix = "keycloak")
+data class KeycloakProperties(
+    val realm: String,
+    val grantType: String,
+    val authServerUrl: String,
+    val clientId: String,
+    val clientSecret: String
+)

--- a/src/main/kotlin/com/jys/kotlin_practice/keycloak/KeycloakRoles.kt
+++ b/src/main/kotlin/com/jys/kotlin_practice/keycloak/KeycloakRoles.kt
@@ -1,5 +1,5 @@
 package com.jys.kotlin_practice.keycloak
 
-object KeyCloakRoles {
+object KeycloakRoles {
     val REST_CLIENT = "rest-client"
 }


### PR DESCRIPTION
## 요약
- #14 기반 바탕으로 에러 정의 통한 사용중 이메일인 에러 케이스 리팩토링
- 409 는 PUT이 일어나는 경우 
- keycloak 설정값 관리 클래스 추가
- Controller 에서 inject bean mocking : mockkBean 수행