### PR TITLE
review: 인증 설정, 라이브러리 추가 및 수정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,10 @@ dependencies {
     implementation("io.projectreactor.kotlin:reactor-kotlin-extensions")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
     implementation("org.keycloak:keycloak-admin-client:20.0.1")
+    runtimeOnly("com.nimbusds:oauth2-oidc-sdk:10.1")
+
 
     testImplementation ("org.springframework.boot:spring-boot-starter-test")
     testImplementation ("org.testcontainers:testcontainers:1.16.3")

--- a/src/main/kotlin/com/jys/kotlin_practice/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/com/jys/kotlin_practice/config/SecurityConfiguration.kt
@@ -19,7 +19,7 @@ class SecurityConfiguration {
         http.csrf().disable().authorizeExchange {
             it.pathMatchers("/account/signin").permitAll()
             it.pathMatchers("/account/signup").permitAll()
-            it.pathMatchers("/account/profile").permitAll()
+            it.pathMatchers("/account/profile").authenticated()
             it.pathMatchers("/css/**").permitAll()
             it.pathMatchers("/js/**").permitAll()
         }.oauth2ResourceServer { it.opaqueToken {  } }.build()


### PR DESCRIPTION
## 요약
- security , oidc 인증을 위한 의존성 라이브러리 추가
- `/account/profile` 인증 하도록 변경
## 테스트
- 프로필 url 인증이 없는 경우: 401
- 프로필 url 인증이 있는 경우: 404