### PR TITLE
인증 정보로부터 subject 추출 로직 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
 
 
     testImplementation ("org.springframework.boot:spring-boot-starter-test")
+    testImplementation ("org.springframework.security:spring-security-test:5.8.0")
     testImplementation ("org.testcontainers:testcontainers:1.16.3")
     testImplementation ("org.testcontainers:junit-jupiter:1.17.2")
     testImplementation ("org.testcontainers:mongodb:1.17.2")

--- a/src/main/kotlin/com/jys/kotlin_practice/account/AccountController.kt
+++ b/src/main/kotlin/com/jys/kotlin_practice/account/AccountController.kt
@@ -1,7 +1,10 @@
 package com.jys.kotlin_practice.account
 
+import com.jys.kotlin_practice.config.subject
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
+import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthentication
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -22,5 +25,14 @@ class AccountController(
     @ResponseStatus(value = HttpStatus.CREATED)
     fun signup(@Valid @RequestBody signupRequest: SignupRequest) {
         accountService.signup(signupRequest)
+    }
+
+    /**
+     * 프로필 조회
+     * @param authentication 인증 정보
+     */
+    @GetMapping(value = ["/profile"])
+    fun getProfile(authentication: BearerTokenAuthentication) {
+        println(authentication.subject)
     }
 }

--- a/src/main/kotlin/com/jys/kotlin_practice/config/AuthenticationExtension.kt
+++ b/src/main/kotlin/com/jys/kotlin_practice/config/AuthenticationExtension.kt
@@ -1,0 +1,9 @@
+package com.jys.kotlin_practice.config
+
+import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthentication
+
+/**
+ * 토큰에서 sub 헤더 추출
+ */
+val BearerTokenAuthentication.subject: String?
+    get() = this.tokenAttributes["sub"]?.toString()

--- a/src/test/kotlin/com/jys/kotlin_practice/account/controller/GetProfileTest.kt
+++ b/src/test/kotlin/com/jys/kotlin_practice/account/controller/GetProfileTest.kt
@@ -1,0 +1,39 @@
+package com.jys.kotlin_practice.account.controller
+
+import io.kotest.core.spec.style.BehaviorSpec
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers.mockOpaqueToken
+
+@SpringBootTest
+@AutoConfigureWebTestClient
+class GetProfileTest(
+    private val webTestClient: WebTestClient
+) : BehaviorSpec({
+    val path = "/account/profile"
+    val customerId = "customerId"
+
+    Given("인증 요청 이전") {
+        When("인증이 올바르지 않은 경우") {
+            val exchange = webTestClient.get().uri(path).exchange()
+            Then("401 Unauthorized") {
+                exchange.expectStatus().isUnauthorized
+            }
+        }
+    }
+
+    Given("인증 요청 이후") {
+        When("인증이 올바르지 않은 경우") {
+            val exchange = webTestClient
+                .mutateWith(mockOpaqueToken().attributes {
+                    it["sub"] = customerId
+                })
+                .get().uri(path).exchange()
+
+            Then("200 isOk") {
+                exchange.expectStatus().isOk
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/jys/kotlin_practice/account/controller/GetProfileTest.kt
+++ b/src/test/kotlin/com/jys/kotlin_practice/account/controller/GetProfileTest.kt
@@ -24,7 +24,7 @@ class GetProfileTest(
     }
 
     Given("인증 요청 이후") {
-        When("인증이 올바르지 않은 경우") {
+        When("프로필 조회 성공한 경우") {
             val exchange = webTestClient
                 .mutateWith(mockOpaqueToken().attributes {
                     it["sub"] = customerId

--- a/src/test/kotlin/com/jys/kotlin_practice/account/controller/GetProfileTest.kt
+++ b/src/test/kotlin/com/jys/kotlin_practice/account/controller/GetProfileTest.kt
@@ -31,7 +31,7 @@ class GetProfileTest(
                 })
                 .get().uri(path).exchange()
 
-            Then("200 isOk") {
+            Then("200 Ok") {
                 exchange.expectStatus().isOk
             }
         }


### PR DESCRIPTION
## 요약
- BearerAunthentication 으로 부터 subject 추출 로직 추가
- `subject` 값은 유저 고유 번호 정보입니다.
- API 요청시 인증 검사 케이스, mock-token 주입 로직 추가